### PR TITLE
Feat : Query DSL 적용 (검색 성능 개선) #145

### DIFF
--- a/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
+++ b/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
@@ -8,6 +8,7 @@ import com.project.comgle.bookmark.repository.BookMarkRepository;
 import com.project.comgle.member.entity.Member;
 import com.project.comgle.member.repository.MemberRepository;
 import com.project.comgle.post.repository.KeywordRepository;
+import com.project.comgle.post.repository.KeywordRepositoryImpl;
 import com.project.comgle.post.repository.PostRepository;
 import com.project.comgle.global.common.response.SuccessResponse;
 import com.project.comgle.bookmark.dto.BookMarkFolderResponseDto;
@@ -35,6 +36,7 @@ public class BookMarkService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final KeywordRepository keywordRepository;
+    private final KeywordRepositoryImpl keywordRepositoryImpl;
 
     // 즐겨찾기 폴더 추가
     @Transactional
@@ -234,7 +236,7 @@ public class BookMarkService {
         for (int i = 0; i < bookMarkList.size(); i++) {
             Optional<Post> findPost = postRepository.findById(bookMarkList.get(i).getPost().getId());
 
-            List<Keyword> keywords = keywordRepository.findAllByPost(findPost.get());
+            List<Keyword> keywords = keywordRepositoryImpl.findAllByPost(findPost.get());
             String[] keywordList = new String[keywords.size()];
 
             for (int j = 0; j < keywords.size(); j++) {

--- a/src/main/java/com/project/comgle/post/repository/KeywordRepository.java
+++ b/src/main/java/com/project/comgle/post/repository/KeywordRepository.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
 
-    List<Keyword> findAllByPost(Post post);
-
-    List<Keyword> findAllByKeywordContains(String keyword);
+//    List<Keyword> findAllByPost(Post post);
+//    List<Keyword> findAllByKeywordContains(String keyword);
     void deleteAllByPost(Post post);
 }
+

--- a/src/main/java/com/project/comgle/post/repository/KeywordRepositoryImpl.java
+++ b/src/main/java/com/project/comgle/post/repository/KeywordRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.project.comgle.post.repository;
+
+import com.project.comgle.post.entity.Keyword;
+import com.project.comgle.post.entity.Post;
+import com.project.comgle.post.entity.QKeyword;
+import com.project.comgle.post.entity.QPost;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@Transactional
+public class KeywordRepositoryImpl {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+    private final QKeyword keyword = QKeyword.keyword1;
+    private final QPost newPost = QPost.post;
+
+    public List<Keyword> findAllByPost(Post post) {
+
+        JPAQuery<Keyword> result = new JPAQuery<>(entityManager);
+        return new ArrayList<>(result.select(keyword)
+                .from(keyword)
+                .innerJoin(keyword.post, newPost).fetchJoin()
+                .where(newPost.id.eq(post.getId()))
+                .distinct()
+                .fetch());
+    }
+
+}

--- a/src/main/java/com/project/comgle/post/repository/PostRepository.java
+++ b/src/main/java/com/project/comgle/post/repository/PostRepository.java
@@ -1,25 +1,40 @@
 package com.project.comgle.post.repository;
 
 import com.project.comgle.member.entity.Member;
+import com.project.comgle.member.entity.QMember;
 import com.project.comgle.post.entity.Post;
+import com.project.comgle.post.entity.QPost;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+//
+import static com.project.comgle.admin.entity.QCategory.category;
+import static com.querydsl.jpa.JPAExpressions.select;
+import static com.querydsl.jpa.JPAExpressions.selectFrom;
+import static com.querydsl.jpa.JPAExpressions.*;
+import static com.querydsl.core.types.dsl.Expressions.*;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 
 public interface PostRepository extends JpaRepository<Post,Long> {
 
     Optional<Post> findByIdAndMember(Long postId, Member member);
-
     Page<Post> findAllByMember(Member member, Pageable pageable);
-
-    Set<Post> findAllByTitleContainsOrContentContaining(String title,String content);
-
+//    Set<Post> findAllByTitleContainsOrContentContaining(String title,String content);
     int countByCategoryId(Long categoryId);
-
     int countByMember(Member member);
-
     Page<Post> findAllByCategoryId(Long categoryId, Pageable pageRequest);
 
 }
+
+

--- a/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.project.comgle.post.repository;
+
+import com.project.comgle.member.entity.QMember;
+import com.project.comgle.post.entity.Keyword;
+import com.project.comgle.post.entity.Post;
+import com.project.comgle.post.entity.QKeyword;
+import com.project.comgle.post.entity.QPost;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.*;
+
+@Repository
+@Transactional
+public class PostRepositoryImpl {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final QPost post = QPost.post;
+    private final QMember member = QMember.member;
+    private final QKeyword keyword = QKeyword.keyword1;
+
+    public List<Post> findAllByContainingKeyword(String k) {
+        JPAQuery<Post> result = new JPAQuery<>(entityManager);
+        return new ArrayList<>(result.select(post)
+                .from(post)
+                .innerJoin(post.member, member).fetchJoin()
+                .innerJoin(post.keywords, keyword).fetchJoin()
+                .where(post.title.contains(k)
+                        .or(post.content.contains(k))
+                        .or(keyword.keyword.contains(k)))
+                .distinct()
+                .fetch());
+    }
+
+}

--- a/src/main/java/com/project/comgle/post/service/PostService.java
+++ b/src/main/java/com/project/comgle/post/service/PostService.java
@@ -7,10 +7,7 @@ import com.project.comgle.comment.repository.CommentRepository;
 import com.project.comgle.member.entity.Member;
 import com.project.comgle.post.dto.PostRequestDto;
 import com.project.comgle.post.entity.*;
-import com.project.comgle.post.repository.EmitterRepository;
-import com.project.comgle.post.repository.KeywordRepository;
-import com.project.comgle.post.repository.LogRepository;
-import com.project.comgle.post.repository.PostRepository;
+import com.project.comgle.post.repository.*;
 import com.project.comgle.global.common.response.MessageResponseDto;
 import com.project.comgle.post.dto.PostResponseDto;
 import com.project.comgle.global.security.UserDetailsImpl;
@@ -33,6 +30,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
     private final KeywordRepository keywordRepository;
+    private final KeywordRepositoryImpl keywordRepositoryImpl;
     private final EmitterRepository emitterRepository;
     private final LogRepository logRepository;
     private final BookMarkRepository bookMarkRepository;
@@ -96,7 +94,7 @@ public class PostService {
 
         String oldContent = findPost.get().getContent();
 
-        List<Keyword> currentKeywords = keywordRepository.findAllByPost(findPost.get());
+        List<Keyword> currentKeywords = keywordRepositoryImpl.findAllByPost(findPost.get());
         List<String> inputKeyWords = new ArrayList<>(Arrays.asList(postRequestDto.getKeywords()));
         List<String> newKeywords = new ArrayList<>();
 
@@ -161,7 +159,7 @@ public class PostService {
             throw new IllegalArgumentException("읽기 가능한 회원 등급이 아닙니다.");
         }
 
-        List<Keyword> keywords = keywordRepository.findAllByPost(post.get());
+        List<Keyword> keywords = keywordRepositoryImpl.findAllByPost(post.get());
         String[] keywordList = new String[keywords.size()];
         for (int i=0; i < keywords.size(); i++) {
             keywordList[i] = keywords.get(i).getKeyword();
@@ -198,9 +196,5 @@ public class PostService {
 
         return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "편집상태 수정"));
     }
-
-
-    // docker test4
-
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/145/querydsl-> dev

### 변경 사항
- TODO1 : PostRepository와 KeywordRepository에서 제목과 내용, 키워드 조회를 각각 조회
-> 동적 쿼리와 fetch join을 통해 한 번에 키워드 조회
-  TODO2 : 이중 for문으로 조회한 키워드들의 post를 다시 postList에 추가
-> 동적 쿼리로 return 받은 타입이 List로 바뀌었으므로, for문 한 번으로 추가 가능

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
