### PR TITLE
Fix : 게시글 상세조회 시 Respone 항목 추가 (#162)

### DIFF
--- a/src/main/java/com/project/comgle/bookmark/controller/BookMarkController.java
+++ b/src/main/java/com/project/comgle/bookmark/controller/BookMarkController.java
@@ -65,12 +65,12 @@ public class BookMarkController {
         return bookMarkService.delBookMark(folderId, postId, userDetails.getMember());
     }
 
-    @ExeTimer
-    @Operation(summary = "즐겨찾기 폴더 별 게시글 조회 API", description = "해당 폴더에 즐겨찾기한 게시글을 모두 조회합니다.")
-    @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping("/bookmark/folder/{folder-id}/bookmarks")
-    public PostPageResponseDto postReadByBookMark(@PathVariable(name = "folder-id") Long folderId, @RequestParam("p") int page, @AuthenticationPrincipal UserDetailsImpl userDetails){
-        return bookMarkService.readPostForBookMark(folderId, page, userDetails.getMember());
-    }
+//    @ExeTimer
+//    @Operation(summary = "즐겨찾기 폴더 별 게시글 조회 API", description = "해당 폴더에 즐겨찾기한 게시글을 모두 조회합니다.")
+//    @ResponseStatus(value = HttpStatus.OK)
+//    @GetMapping("/bookmark/folder/{folder-id}/bookmarks")
+//    public PostPageResponseDto postReadByBookMark(@PathVariable(name = "folder-id") Long folderId, @RequestParam("p") int page, @AuthenticationPrincipal UserDetailsImpl userDetails){
+//        return bookMarkService.readPostForBookMark(folderId, page, userDetails.getMember());
+//    }
 
 }

--- a/src/main/java/com/project/comgle/bookmark/repository/BookMarkRepository.java
+++ b/src/main/java/com/project/comgle/bookmark/repository/BookMarkRepository.java
@@ -1,14 +1,21 @@
 package com.project.comgle.bookmark.repository;
 
 import com.project.comgle.bookmark.entity.BookMark;
+import com.project.comgle.member.entity.Member;
 import com.project.comgle.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
+
+    @Query("SELECT f.id from BookMarkFolder f join BookMark b on f.id = b.bookMarkFolder.id where f.member = :member and b.post = :post")
+    List<Integer> findFoldersByPost(@Param("member") Member member, @Param("post") Post post);
 
     Optional<BookMark> findByBookMarkFolderIdAndPostId(Long folderId, Long postId);
 

--- a/src/main/java/com/project/comgle/post/dto/PostResponseDto.java
+++ b/src/main/java/com/project/comgle/post/dto/PostResponseDto.java
@@ -1,6 +1,7 @@
 package com.project.comgle.post.dto;
 
 import com.project.comgle.global.utils.SchemaDescriptionUtils;
+import com.project.comgle.member.entity.PositionEnum;
 import com.project.comgle.post.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -32,7 +33,6 @@ public class PostResponseDto {
     @Schema(description = SchemaDescriptionUtils.Category.NAME, example = "공지사항")
     private String category;
 
-
     @Schema(description = SchemaDescriptionUtils.Keyword.NAME)
     private String[] keywords;
 
@@ -42,8 +42,21 @@ public class PostResponseDto {
     @Schema(description = SchemaDescriptionUtils.Post.EditingStatus)
     private String editingStatus;
 
+    @Schema(description = SchemaDescriptionUtils.Post.MEDIFY_PERMISSION)
+    private PositionEnum modifyPermission;
+
+    @Schema(description = SchemaDescriptionUtils.Post.READABLE_POSITION)
+    private PositionEnum readablePosition;
+
+    @Schema(description = SchemaDescriptionUtils.Post.READABLE_POSITION)
+    private Integer[] folders;
+
     @Builder
-    private PostResponseDto(Long id, String memberName, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, String category, String[] keywords, int postViews, String editingStatus) {
+    private PostResponseDto(Long id, String memberName, String title, String content,
+                            LocalDateTime createdAt, LocalDateTime modifiedAt, String category,
+                            String[] keywords, int postViews, String editingStatus,
+                            PositionEnum modifyPermission, PositionEnum readablePosition,
+                            Integer[] folders) {
         this.id = id;
         this.memberName = memberName;
         this.title = title;
@@ -54,6 +67,9 @@ public class PostResponseDto {
         this.keywords = keywords;
         this.postViews = postViews;
         this.editingStatus = editingStatus;
+        this.modifyPermission = modifyPermission;
+        this.readablePosition = readablePosition;
+        this.folders = folders;
     }
 
     public static PostResponseDto of(Post post, String category, String[] keywords) {
@@ -66,10 +82,12 @@ public class PostResponseDto {
                 .modifiedAt(post.getModifiedAt())
                 .category(category)
                 .keywords(keywords)
+                .modifyPermission(post.getModifyPermission())
+                .readablePosition(post.getReadablePosition())
                 .build();
     }
 
-    public static PostResponseDto of(Post post, String category, String[] keywords, int postViews) {
+    public static PostResponseDto of(Post post, String category, String[] keywords, Integer[] folders,int postViews) {
         return PostResponseDto.builder()
                 .id(post.getId())
                 .memberName(post.getMember().getMemberName())
@@ -81,6 +99,9 @@ public class PostResponseDto {
                 .keywords(keywords)
                 .postViews(postViews)
                 .editingStatus(post.getEditingStatus())
+                .modifyPermission(post.getModifyPermission())
+                .readablePosition(post.getReadablePosition())
+                .folders(folders)
                 .build();
     }
 }

--- a/src/main/java/com/project/comgle/post/repository/KeywordRepositoryImpl.java
+++ b/src/main/java/com/project/comgle/post/repository/KeywordRepositoryImpl.java
@@ -22,7 +22,6 @@ public class KeywordRepositoryImpl {
     private final QPost newPost = QPost.post;
 
     public List<Keyword> findAllByPost(Post post) {
-
         JPAQuery<Keyword> result = new JPAQuery<>(entityManager);
         return new ArrayList<>(result.select(keyword)
                 .from(keyword)

--- a/src/main/java/com/project/comgle/post/service/PostService.java
+++ b/src/main/java/com/project/comgle/post/service/PostService.java
@@ -160,9 +160,8 @@ public class PostService {
 
         List<Keyword> keywords = keywordRepositoryImpl.findAllByPost(post);
         String[] keywordList = keywords.stream().map(Keyword::getKeyword).toArray(String[]::new);
-
+        Integer[] folders = bookMarkRepository.findFoldersByPost(member, post).toArray(Integer[]::new);
         findPost.get().updateMethod(WeightEnum.POSTVIEWS.getNum());
-        postRepository.saveAndFlush(post);
 
         int postViews = post.getPostViews();
 
@@ -171,6 +170,7 @@ public class PostService {
                         PostResponseDto.of( findPost.get(),
                                 findPost.get().getCategory().getCategoryName(),
                                 keywordList,
+                                folders,
                                 postViews)
                 );
     }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
fix/162/add-post-detail-response -> dev

### 변경 사항
- 사용자가 해당 게시글을 즐겨찾기한 폴더번호
- 수정권한
- 읽기권한

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
