### PR TITLE
Refactor : Mypage 리팩토링 (#176)

### DIFF
--- a/src/main/java/com/project/comgle/bookmark/controller/BookMarkController.java
+++ b/src/main/java/com/project/comgle/bookmark/controller/BookMarkController.java
@@ -69,7 +69,7 @@ public class BookMarkController {
     @Operation(summary = "즐겨찾기 폴더 별 게시글 조회 API", description = "해당 폴더에 즐겨찾기한 게시글을 모두 조회합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/bookmark/folder/{folder-id}/bookmarks")
-    public PostPageResponseDto postReadByBookMark(@PathVariable(name = "folder-id") Long folderId, @RequestParam(value = "p", defaultValue = "1") int page, @AuthenticationPrincipal UserDetailsImpl userDetails){
+    public PostPageResponseDto postReadByBookMark(@PathVariable(name = "folder-id") Long folderId, @RequestParam(value = "page", defaultValue = "1") int page, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return bookMarkService.readPostForBookMark(folderId, page, userDetails.getMember());
     }
 

--- a/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
+++ b/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
@@ -227,14 +227,14 @@ public class BookMarkService {
         for(BookMark b : bookMarkList){
 
             Post findPost = b.getPost();
-            List<Comment> allByPost = commentRepository.findAllByPost(findPost);
+            int commentCount = commentRepository.findAllByPost(findPost).size();
             String[] keywordList = findPost.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
 
             postResponseDtoList.add(PostResponseDto.of(
                     findPost,
                     findPost.getCategory().getCategoryName(),
                     keywordList,
-                    allByPost.size()));
+                    commentCount));
         }
 
         return PostPageResponseDto.of(endP,postResponseDtoList);

--- a/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
+++ b/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
@@ -1,5 +1,7 @@
 package com.project.comgle.bookmark.service;
 
+import com.project.comgle.comment.entity.Comment;
+import com.project.comgle.comment.repository.CommentRepository;
 import com.project.comgle.post.dto.PostPageResponseDto;
 import com.project.comgle.bookmark.entity.BookMark;
 import com.project.comgle.bookmark.entity.BookMarkFolder;
@@ -35,7 +37,8 @@ public class BookMarkService {
     private final BookMarkRepository bookMarkRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
-    private final KeywordRepositoryImpl keywordRepositoryImpl;
+    private final CommentRepository commentRepository;
+
 
     // 즐겨찾기 폴더 추가
     @Transactional
@@ -224,11 +227,14 @@ public class BookMarkService {
         for(BookMark b : bookMarkList){
 
             Post findPost = b.getPost();
+            List<Comment> allByPost = commentRepository.findAllByPost(findPost);
             String[] keywordList = findPost.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
 
-            postResponseDtoList.add(PostResponseDto.of(findPost,
+            postResponseDtoList.add(PostResponseDto.of(
+                    findPost,
                     findPost.getCategory().getCategoryName(),
-                    keywordList));
+                    keywordList,
+                    allByPost.size()));
         }
 
         return PostPageResponseDto.of(endP,postResponseDtoList);

--- a/src/main/java/com/project/comgle/mypage/controller/MyPageController.java
+++ b/src/main/java/com/project/comgle/mypage/controller/MyPageController.java
@@ -26,7 +26,7 @@ public class MyPageController {
     @Operation(summary = "내 게시글 전체조회 API", description = "내가 작성한 게시글 전체를 조회합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/mypage/posts")
-    public PostPageResponseDto myPostList(@RequestParam("p") int page, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public PostPageResponseDto myPostList(@RequestParam(value = "p", defaultValue = "1") int page, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return myPageService.listMyPost(page, userDetails);
     }
 

--- a/src/main/java/com/project/comgle/mypage/controller/MyPageController.java
+++ b/src/main/java/com/project/comgle/mypage/controller/MyPageController.java
@@ -26,7 +26,7 @@ public class MyPageController {
     @Operation(summary = "내 게시글 전체조회 API", description = "내가 작성한 게시글 전체를 조회합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/mypage/posts")
-    public PostPageResponseDto myPostList(@RequestParam(value = "p", defaultValue = "1") int page, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public PostPageResponseDto myPostList(@RequestParam(value = "page", defaultValue = "1") int page, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return myPageService.listMyPost(page, userDetails);
     }
 

--- a/src/main/java/com/project/comgle/mypage/service/MyPageService.java
+++ b/src/main/java/com/project/comgle/mypage/service/MyPageService.java
@@ -32,8 +32,8 @@ public class MyPageService {
         List<PostResponseDto> postResponseDtoList = postRepositorys.findAllByMember(page, userDetails.getMember().getId())
                 .stream().map(k -> {
                     String[] keywordList = k.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
-                    List<Comment> allByPost = commentRepository.findAllByPost(k);
-                    return PostResponseDto.of(k, k.getCategory().getCategoryName(), keywordList, allByPost.size());}
+                    int commentCount = commentRepository.findAllByPost(k).size();
+                    return PostResponseDto.of(k, k.getCategory().getCategoryName(), keywordList, commentCount);}
                 ).collect(Collectors.toList());
 
         int totalCount = postRepositorys.findAllByMemberCount(userDetails.getMember().getId()).size();

--- a/src/main/java/com/project/comgle/mypage/service/MyPageService.java
+++ b/src/main/java/com/project/comgle/mypage/service/MyPageService.java
@@ -1,65 +1,45 @@
 package com.project.comgle.mypage.service;
 
+import com.project.comgle.comment.entity.Comment;
+import com.project.comgle.comment.repository.CommentRepository;
 import com.project.comgle.post.dto.PostPageResponseDto;
-import com.project.comgle.global.exception.CustomException;
-import com.project.comgle.global.exception.ExceptionEnum;
 import com.project.comgle.member.dto.MemberResponseDto;
 import com.project.comgle.member.entity.Member;
 import com.project.comgle.member.repository.MemberRepository;
 import com.project.comgle.post.dto.PostResponseDto;
 import com.project.comgle.post.entity.Keyword;
-import com.project.comgle.post.entity.Post;
 import com.project.comgle.post.repository.PostRepository;
 import com.project.comgle.global.security.UserDetailsImpl;
+import com.project.comgle.post.repository.PostRepositoryImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
 
-    private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final PostRepositoryImpl postRepositorys;
+    private final CommentRepository commentRepository;
 
     @Transactional(readOnly = true)
     public PostPageResponseDto listMyPost(int page, UserDetailsImpl userDetails) {
 
-        int nowPage = page-1;   // 현재 페이지
-        int size = 10;  // 한 페이지당 게시글 수
+        List<PostResponseDto> postResponseDtoList = postRepositorys.findAllByMember(page, userDetails.getMember().getId())
+                .stream().map(k -> {
+                    String[] keywordList = k.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
+                    List<Comment> allByPost = commentRepository.findAllByPost(k);
+                    return PostResponseDto.of(k, k.getCategory().getCategoryName(), keywordList, allByPost.size());}
+                ).collect(Collectors.toList());
 
-        List<Post> allMyPosts = postRepository.findAllByMember(userDetails.getMember(), PageRequest.of(nowPage, size)).toList();
+        int totalCount = postRepositorys.findAllByMemberCount(userDetails.getMember().getId()).size();
+        int endPage = totalCount%10 != 0 ? totalCount/10+1 : totalCount/10;
 
-        if(allMyPosts.isEmpty()){
-            throw new CustomException(ExceptionEnum.NOT_EXIST_POST);
-        }
-
-        int endP = postRepository.countByMember(userDetails.getMember());
-        if(endP % size == 0){
-            endP = endP / size;
-        } else if (endP % size > 0) {
-            endP = endP / size + 1;
-        }
-
-        List<PostResponseDto> responseDtos = new ArrayList<>();
-        for (Post post : allMyPosts) {
-            List<Keyword> keywords = post.getKeywords();
-            String[] keyword = new String[keywords.size()];
-            for (int i = 0; i < keywords.size(); i++) {
-                keyword[i] = keywords.get(i).getKeyword();
-            }
-            responseDtos.add(PostResponseDto.of(post, post.getCategory().getCategoryName(), keyword));
-        }
-
-        if(responseDtos.isEmpty()){
-            throw new CustomException(ExceptionEnum.NOT_EXIST_POST);
-        }
-
-        return PostPageResponseDto.of(endP,responseDtos);
+        return PostPageResponseDto.of(endPage, postResponseDtoList);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/project/comgle/post/dto/PostResponseDto.java
+++ b/src/main/java/com/project/comgle/post/dto/PostResponseDto.java
@@ -51,12 +51,14 @@ public class PostResponseDto {
     @Schema(description = SchemaDescriptionUtils.Post.READABLE_POSITION)
     private Integer[] folders;
 
+    private int commentCount;
+
     @Builder
     private PostResponseDto(Long id, String memberName, String title, String content,
                             LocalDateTime createdAt, LocalDateTime modifiedAt, String category,
                             String[] keywords, int postViews, String editingStatus,
                             PositionEnum modifyPermission, PositionEnum readablePosition,
-                            Integer[] folders) {
+                            Integer[] folders, int commentCount) {
         this.id = id;
         this.memberName = memberName;
         this.title = title;
@@ -70,9 +72,10 @@ public class PostResponseDto {
         this.modifyPermission = modifyPermission;
         this.readablePosition = readablePosition;
         this.folders = folders;
+        this.commentCount = commentCount;
     }
 
-    public static PostResponseDto of(Post post, String category, String[] keywords) {
+    public static PostResponseDto of(Post post, String category, String[] keywords, int commentCount) {
         return PostResponseDto.builder()
                 .id(post.getId())
                 .memberName(post.getMember().getMemberName())
@@ -84,10 +87,11 @@ public class PostResponseDto {
                 .keywords(keywords)
                 .modifyPermission(post.getModifyPermission())
                 .readablePosition(post.getReadablePosition())
+                .commentCount(commentCount)
                 .build();
     }
 
-    public static PostResponseDto of(Post post, String category, String[] keywords, Integer[] folders,int postViews) {
+    public static PostResponseDto of(Post post, String category, String[] keywords, Integer[] folders, int postViews, int commentCount) {
         return PostResponseDto.builder()
                 .id(post.getId())
                 .memberName(post.getMember().getMemberName())
@@ -102,6 +106,7 @@ public class PostResponseDto {
                 .modifyPermission(post.getModifyPermission())
                 .readablePosition(post.getReadablePosition())
                 .folders(folders)
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
@@ -103,6 +103,34 @@ public class PostRepositoryImpl {
                 .fetch());
     }
 
+    public Page<Post> findAllByMember(int page, Long memberId) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(post.member.id.eq(memberId));
+
+        JPAQuery<Post> result = new JPAQuery<>(entityManager);
+        return new PageImpl<>(result.select(post)
+                .from(post)
+                .join(post.member, member).fetchJoin()
+                .where(builder)
+                .distinct()
+                .offset((page-1)*10)
+                .limit(10)
+                .fetch());
+    }
+
+    public List<Post> findAllByMemberCount(Long memberId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(post.member.id.eq(memberId));
+        JPAQuery<Post> result = new JPAQuery<>(entityManager);
+        return new ArrayList<>(result.select(post)
+                .from(post)
+                .join(post.member, member).fetchJoin()
+                .where(builder)
+                .distinct()
+                .fetch());
+    }
+
    private OrderSpecifier<?> sortingFilter(String sortType) {
         Order order = Order.DESC;
 

--- a/src/main/java/com/project/comgle/post/service/PostService.java
+++ b/src/main/java/com/project/comgle/post/service/PostService.java
@@ -163,7 +163,7 @@ public class PostService {
         String[] keywordList = keywords.stream().map(Keyword::getKeyword).toArray(String[]::new);
         Integer[] folders = bookMarkRepository.findFoldersByPost(member, post).toArray(Integer[]::new);
         findPost.get().updateMethod(WeightEnum.POSTVIEWS.getNum());
-        List<Comment> allByPost = commentRepository.findAllByPost(post);
+        int commentCount = commentRepository.findAllByPost(post).size();
 
         int postViews = post.getPostViews();
 
@@ -174,7 +174,7 @@ public class PostService {
                                 keywordList,
                                 folders,
                                 postViews,
-                                allByPost.size())
+                                commentCount)
                 );
     }
 

--- a/src/main/java/com/project/comgle/post/service/PostService.java
+++ b/src/main/java/com/project/comgle/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.project.comgle.post.service;
 import com.project.comgle.admin.entity.Category;
 import com.project.comgle.admin.repository.CategoryRepository;
 import com.project.comgle.bookmark.repository.BookMarkRepository;
+import com.project.comgle.comment.entity.Comment;
 import com.project.comgle.comment.repository.CommentRepository;
 import com.project.comgle.company.entity.Company;
 import com.project.comgle.global.common.response.MessageResponseDto;
@@ -162,6 +163,7 @@ public class PostService {
         String[] keywordList = keywords.stream().map(Keyword::getKeyword).toArray(String[]::new);
         Integer[] folders = bookMarkRepository.findFoldersByPost(member, post).toArray(Integer[]::new);
         findPost.get().updateMethod(WeightEnum.POSTVIEWS.getNum());
+        List<Comment> allByPost = commentRepository.findAllByPost(post);
 
         int postViews = post.getPostViews();
 
@@ -171,7 +173,8 @@ public class PostService {
                                 findPost.get().getCategory().getCategoryName(),
                                 keywordList,
                                 folders,
-                                postViews)
+                                postViews,
+                                allByPost.size())
                 );
     }
 

--- a/src/main/java/com/project/comgle/post/service/SearchService.java
+++ b/src/main/java/com/project/comgle/post/service/SearchService.java
@@ -37,8 +37,8 @@ public class SearchService {
         List<SearchResponseDto> searchResponseDtoList = postRepositorys.findAllByContainingKeyword(page, keywordResult, sortType, company.getId())
                 .stream().map(k -> {
                             String[] key = k.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
-                            List<Comment> allByPost = commentRepository.findAllByPost(k);
-                            return SearchResponseDto.of(k, key, allByPost.size());
+                            int commentCount = commentRepository.findAllByPost(k).size();
+                            return SearchResponseDto.of(k, key, commentCount);
                         }
                 ).collect(Collectors.toList());
 
@@ -54,8 +54,8 @@ public class SearchService {
         List<SearchResponseDto> searchResponseDtoList = postRepositorys.findAllByContainingCategory(page, category, sortType, company.getId())
                 .stream().map(k -> {
                     String[] key = k.getKeywords().stream().map(Keyword::getKeyword).toArray(String[]::new);
-                    List<Comment> allByPost = commentRepository.findAllByPost(k);
-                    return SearchResponseDto.of(k, key, allByPost.size());}
+                    int commentCount = commentRepository.findAllByPost(k).size();
+                    return SearchResponseDto.of(k, key, commentCount);}
                 ).collect(Collectors.toList());
 
         int totalCount = postRepositorys.findAllByContainingCategoryCount(category, company.getId()).size();


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
refactor/176/mypage-refactor-> dev

### 변경 사항
- mypage Service 2중 for문 개선
- 폴더별 게시글 조회, 마이페이지 게시글 조회 commentCount 추가

### 테스트 결과
Postman 테스트 결과 이상 없습니다.

즐겨찾기 폴더별 게시글 조회, 마이페이지 게시글 조회 다음과 같이 나옴 : 

{
    "endPage": 2,
    "postResponseDtoList": [
        {
            "id": 1,
            "memberName": "애플",
            "title": "제목입니당3",
            "content": "내용입니당",
            "createdAt": "2023-04-12T20:37:58.307198",
            "modifiedAt": "2023-04-12T20:38:25.365632",
            "category": "공지",
            "keywords": [
                "키워드",
                "딸기"
            ],
            "postViews": 0,
            "editingStatus": null,
            "modifyPermission": "MEMBER",
            "readablePosition": "MEMBER",
            "folders": null,
            "commentCount": 0
        }
    ]
}