### PR TITLE
Fix : 검색 정렬 조건 수정 #181

### DIFF
--- a/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
+++ b/src/main/java/com/project/comgle/bookmark/service/BookMarkService.java
@@ -223,7 +223,8 @@ public class BookMarkService {
         int size = 10;
 
         Page<BookMark> bookMarkList = bookMarkRepository.findAllByBookMarkFolderId(findBookMarkFolder.get(), PageRequest.of(nowPage, size));
-        int endP = bookMarkList.getTotalPages();
+        int endPage = bookMarkList.getTotalPages();
+        int totalPost = bookMarkList.getNumberOfElements();
 
         List<PostResponseDto> postResponseDtoList = new ArrayList<>();
 
@@ -244,7 +245,7 @@ public class BookMarkService {
                     commentCount));
         }
 
-        return PostPageResponseDto.of(endP,postResponseDtoList);
+        return PostPageResponseDto.of(endPage, totalPost, postResponseDtoList);
     }
 
 }

--- a/src/main/java/com/project/comgle/mypage/service/MyPageService.java
+++ b/src/main/java/com/project/comgle/mypage/service/MyPageService.java
@@ -38,10 +38,10 @@ public class MyPageService {
                     return PostResponseDto.of(k, k.getCategory().getCategoryName(), keywordList, commentCount);}
                 ).collect(Collectors.toList());
 
-        int totalCount = postRepositorys.findAllByMemberCount(userDetails.getMember().getId()).size();
-        int endPage = totalCount%10 != 0 ? totalCount/10+1 : totalCount/10;
+        int totalPost = postRepositorys.findAllByMemberCount(userDetails.getMember().getId()).size();
+        int endPage = totalPost%10 != 0 ? totalPost/10+1 : totalPost/10;
 
-        return PostPageResponseDto.of(endPage, postResponseDtoList);
+        return PostPageResponseDto.of(endPage, totalPost, postResponseDtoList);
 
     }
 

--- a/src/main/java/com/project/comgle/post/controller/SearchController.java
+++ b/src/main/java/com/project/comgle/post/controller/SearchController.java
@@ -25,9 +25,9 @@ public class SearchController {
     @Operation(summary = "키워드 조회 API", description = "제목, 내용, 키워드로 검색하는 기능입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/search")
-    public SearchPageResponseDto keywordSearch(@RequestParam(defaultValue = "1") int page,
+    public SearchPageResponseDto keywordSearch(@RequestParam(value = "page", defaultValue = "1") int page,
                                                  @RequestParam(value = "keyword") String keyword,
-                                                 @RequestParam(defaultValue = "관심도") String sortType,
+                                                 @RequestParam(value = "sort", defaultValue = "조회수") String sortType,
                                                  @AuthenticationPrincipal UserDetailsImpl userDetails){
         return searchService.searchKeyword(page, keyword, sortType, userDetails.getCompany());
     }
@@ -36,9 +36,9 @@ public class SearchController {
     @Operation(summary = "카테고리 조회 API", description = "해당 카테고리로 조회하는 기능입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/category")
-    public SearchPageResponseDto categorySearch(@RequestParam(defaultValue = "1") int page,
+    public SearchPageResponseDto categorySearch(@RequestParam(value = "page", defaultValue = "1") int page,
                                                   @RequestParam(value = "category") String category,
-                                                  @RequestParam(defaultValue = "관심도") String sortType,
+                                                  @RequestParam(value = "sort", defaultValue = "조회수") String sortType,
                                                   @AuthenticationPrincipal UserDetailsImpl userDetails){
         return searchService.searchCategory(page, category, sortType, userDetails.getCompany());
     }

--- a/src/main/java/com/project/comgle/post/dto/PostPageResponseDto.java
+++ b/src/main/java/com/project/comgle/post/dto/PostPageResponseDto.java
@@ -9,18 +9,21 @@ import java.util.List;
 public class PostPageResponseDto {
 
     private int endPage;
+    private int totalPost;
 
     private List<PostResponseDto> postResponseDtoList;
 
     @Builder
-    private PostPageResponseDto(int endPage, List<PostResponseDto> postResponseDtoList) {
+    private PostPageResponseDto(int endPage, int totalPost, List<PostResponseDto> postResponseDtoList) {
         this.endPage = endPage;
+        this.totalPost = totalPost;
         this.postResponseDtoList = postResponseDtoList;
     }
 
-    public static PostPageResponseDto of(int endPage, List<PostResponseDto> postResponseDtoList){
+    public static PostPageResponseDto of(int endPage, int totalPost, List<PostResponseDto> postResponseDtoList){
         return PostPageResponseDto.builder()
                 .endPage(endPage)
+                .totalPost(totalPost)
                 .postResponseDtoList(postResponseDtoList)
                 .build();
     }

--- a/src/main/java/com/project/comgle/post/dto/SearchPageResponseDto.java
+++ b/src/main/java/com/project/comgle/post/dto/SearchPageResponseDto.java
@@ -8,18 +8,21 @@ import java.util.List;
 public class SearchPageResponseDto {
 
     private int endPage;
+    private int totalPost;
 
     private List<SearchResponseDto> searchResponseDtoList;
 
     @Builder
-    private SearchPageResponseDto(int endPage, List<SearchResponseDto> searchResponseDtoList) {
+    private SearchPageResponseDto(int endPage, int totalPost, List<SearchResponseDto> searchResponseDtoList) {
         this.endPage = endPage;
+        this.totalPost = totalPost;
         this.searchResponseDtoList = searchResponseDtoList;
     }
 
-    public static SearchPageResponseDto of(int endPage, List<SearchResponseDto> searchResponseDtoList){
+    public static SearchPageResponseDto of(int endPage, int totalPost, List<SearchResponseDto> searchResponseDtoList){
         return SearchPageResponseDto.builder()
                 .endPage(endPage)
+                .totalPost(totalPost)
                 .searchResponseDtoList(searchResponseDtoList)
                 .build();
     }

--- a/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/project/comgle/post/repository/PostRepositoryImpl.java
@@ -39,6 +39,7 @@ public class PostRepositoryImpl {
 
         builder.and(post.member.company.id.eq(companyId)
                 .and(post.valid.eq(true)));
+
         JPAQuery<Post> result = new JPAQuery<>(entityManager);
         return new PageImpl<>(result.select(post)
                 .from(post)
@@ -62,6 +63,7 @@ public class PostRepositoryImpl {
 
         builder.and(post.member.company.id.eq(companyId))
                 .and(post.valid.eq(true));
+
         JPAQuery<Post> result = new JPAQuery<>(entityManager);
         return new ArrayList<>(result.select(post)
                 .from(post)
@@ -136,20 +138,17 @@ public class PostRepositoryImpl {
                 .fetch());
     }
 
-   private OrderSpecifier<?> sortingFilter(String sortType) {
-        Order order = Order.DESC;
-
-        if (sortType.equals("관심도")) {
-            return new OrderSpecifier<>(order, post.score);
-        } else if (sortType.equals("조회수")) {
-            return new OrderSpecifier<>(order, post.postViews);
-        } else if (sortType.equals("댓글수")) {
-            return new OrderSpecifier<>(order, post.comments.size());
-        } else if (sortType.equals("생성일자")) {
-            return new OrderSpecifier<>(order, post.createdAt);
+    private OrderSpecifier<?> sortingFilter(String sortType) {
+        switch (sortType) {
+            case "관심도":
+                return new OrderSpecifier<>(Order.DESC, post.score);
+            case "댓글수":
+                return new OrderSpecifier<>(Order.DESC, post.comments.size());
+            case "생성일자":
+                return new OrderSpecifier<>(Order.DESC, post.createdAt);
         }
 
-        return null;
-   }
+        return new OrderSpecifier<>(Order.DESC, post.postViews);
+    }
 }
 

--- a/src/main/java/com/project/comgle/post/service/SearchService.java
+++ b/src/main/java/com/project/comgle/post/service/SearchService.java
@@ -42,10 +42,10 @@ public class SearchService {
                         }
                 ).collect(Collectors.toList());
 
-        int totalCount = postRepositorys.findAllByContainingKeywordCount(keywordResult, company.getId()).size();
-        int endPage = totalCount%10 != 0 ? totalCount/10+1 : totalCount/10;
+        int totalPost = postRepositorys.findAllByContainingKeywordCount(keywordResult, company.getId()).size();
+        int endPage = totalPost%10 != 0 ? totalPost/10+1 : totalPost/10;
 
-        return SearchPageResponseDto.of(endPage, searchResponseDtoList);
+        return SearchPageResponseDto.of(endPage, totalPost, searchResponseDtoList);
     }
 
     @Transactional
@@ -58,10 +58,10 @@ public class SearchService {
                     return SearchResponseDto.of(k, key, commentCount);}
                 ).collect(Collectors.toList());
 
-        int totalCount = postRepositorys.findAllByContainingCategoryCount(category, company.getId()).size();
-        int endPage = totalCount%10 != 0 ? totalCount/10+1 : totalCount/10;
+        int totalPost = postRepositorys.findAllByContainingCategoryCount(category, company.getId()).size();
+        int endPage = totalPost%10 != 0 ? totalPost/10+1 : totalPost/10;
 
-        return SearchPageResponseDto.of(endPage, searchResponseDtoList);
+        return SearchPageResponseDto.of(endPage, totalPost, searchResponseDtoList);
     }
 
     private Set<String> getWords(String keyword) {


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
Fix/181/search-> dev

### 변경 사항
- 관심도 제외 조회수, 댓글수, 생성일자 정렬에서 버그 수정
- Orderby에서 사용하는 메서드 리펙토링
- 검색 조회 시 Response에 총 게시글 개수도 포함

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
